### PR TITLE
Bump Version Of nfde Package To Make Project Compile Again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 slint = "1.13.1"
-nfde = "0.0.8"
+nfde = "0.0.9"
 image = "0.25"
 kamadak-exif = "0.6"
 chrono = "0.4"


### PR DESCRIPTION
nfde version 0.0.8 has a problem with cmake which version 0.0.9 takes care of.